### PR TITLE
Move DefaultFallback static to the end

### DIFF
--- a/src/DnsClient/NameServer.public.cs
+++ b/src/DnsClient/NameServer.public.cs
@@ -9,13 +9,6 @@ namespace DnsClient
 {
     public partial class NameServer
     {
-        /// <summary>Default fallback nameservers.</summary>
-        public static readonly IEnumerable<NameServer> DefaultFallback = new NameServer[]
-        {
-            GooglePublicDns, GooglePublicDns2, GooglePublicDnsIPv6, GooglePublicDns2IPv6,
-            CloudflarePublicDns, CloudflarePublicDns2, CloudflarePublicDnsIPv6, CloudflarePublicDns2IPv6
-        };
-        
         /// <summary>A public Google DNS IPv4 nameserver.</summary>
         public static readonly NameServer GooglePublicDns = new IPEndPoint(IPAddress.Parse("8.8.4.4"), DefaultPort);
 
@@ -39,5 +32,12 @@ namespace DnsClient
 
         /// <summary>A public Cloudflare DNS IPv6 nameserver.</summary>
         public static readonly NameServer CloudflarePublicDns2IPv6 = new IPEndPoint(IPAddress.Parse("2606:4700:4700::1001"), DefaultPort);
+
+        /// <summary>Default fallback nameservers.</summary>
+        public static readonly IEnumerable<NameServer> DefaultFallback = new NameServer[]
+        {
+            GooglePublicDns, GooglePublicDns2, GooglePublicDnsIPv6, GooglePublicDns2IPv6,
+            CloudflarePublicDns, CloudflarePublicDns2, CloudflarePublicDnsIPv6, CloudflarePublicDns2IPv6
+        };
     }
 }


### PR DESCRIPTION
This is what happens when you try to read variables before them being written to... as in, static variables are initialized in order, so DefaultFallback was reading nulls

What a nice quirk!